### PR TITLE
W05: add Contact Us page with map, staff, form; append CSS; wireframe link

### DIFF
--- a/wwr/contact.html
+++ b/wwr/contact.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Contact Whitewater Rafting Co. with general inquiries, reservation questions, or website suggestions. Find our phone, email, address, and map.">
+  <meta name="author" content="Alejandro Vanderhorst">
+  <title>Whitewater Rafting Co. | Contact Us</title>
+  <link rel="stylesheet" href="styles/rafting.css">
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header>
+    <img src="images/my_logo.png" alt="Rafting Site Logo" class="logo">
+    <nav class="nav-bar">
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="trips.html">Trips</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </header>
+
+  <main id="main-content" class="contact">
+  <h1>Contact Us</h1>
+
+  <section class="contact__grid" aria-labelledby="contact-info-heading">
+    <div class="contact__info">
+      <h2 id="contact-info-heading">Company Information</h2>
+      <address class="vcard">
+        <p class="org">Whitewater Rafting Co.</p>
+        <p class="adr">
+          <span class="street-address">123 River Run Rd</span><br />
+          <span class="locality">Jackson</span>,
+          <span class="region">WY</span>
+          <span class="postal-code">83001</span>
+        </p>
+        <p>
+          Phone: <a class="tel" href="tel:+13075550123">+1 (307) 555‑0123</a><br />
+          Email: <a class="email" href="mailto:info@whitewaterrafting.example">info@whitewaterrafting.example</a>
+        </p>
+      </address>
+
+      <div class="contact__map" aria-label="Our location on Google Maps">
+        <iframe
+          title="Whitewater Rafting Co. location"
+          loading="lazy"
+          allowfullscreen
+          referrerpolicy="no-referrer-when-downgrade"
+          src="https://www.google.com/maps?q=123%20River%20Run%20Rd%20Jackson%20WY%2083001&output=embed">
+        </iframe>
+      </div>
+    </div>
+
+    <form class="contact__form" action="#" method="post" aria-describedby="form-help">
+      <h2>Send us a message</h2>
+
+      <div class="form__field">
+        <label for="fullname">Full name</label>
+        <input id="fullname" name="fullname" type="text" autocomplete="name" required />
+      </div>
+
+      <div class="form__field">
+        <label for="email">Email address</label>
+        <input id="email" name="email" type="email" autocomplete="email" required />
+      </div>
+
+      <fieldset class="form__field" aria-describedby="purpose-help">
+        <legend>Purpose of your message</legend>
+        <p id="purpose-help" class="form__hint">Choose one option</p>
+        <div class="radio-group">
+          <label class="radio">
+            <input type="radio" name="purpose" value="general" required />
+            General Inquiry
+          </label>
+          <label class="radio">
+            <input type="radio" name="purpose" value="reservation" />
+            Reservation Question
+          </label>
+          <label class="radio">
+            <input type="radio" name="purpose" value="website" />
+            Website Suggestion
+          </label>
+        </div>
+      </fieldset>
+
+      <div class="form__field">
+        <label for="message">Your message</label>
+        <textarea id="message" name="message" rows="6" required></textarea>
+      </div>
+
+      <div class="form__field form__inline">
+        <input id="subscribe" name="subscribe" type="checkbox" />
+        <label for="subscribe">Please subscribe me to the monthly newsletter</label>
+      </div>
+
+      <p id="form-help" class="form__hint">All fields marked required must be completed.</p>
+
+      <button class="btn btn--primary" type="submit">Send Message</button>
+    </form>
+  </section>
+
+  <section class="staff" aria-labelledby="staff-heading">
+    <h2 id="staff-heading">Meet our team</h2>
+    <div class="staff__grid">
+      <figure class="card">
+        <img src="images/staff-1.jpg" width="400" height="400" alt="Smiling river guide wearing a life jacket" />
+        <figcaption>
+          <span class="staff__name">Ava Thompson</span>
+          <span class="staff__title">Lead River Guide</span>
+        </figcaption>
+      </figure>
+      <figure class="card">
+        <img src="images/staff-2.jpg" width="400" height="400" alt="Friendly receptionist at the rafting lodge" />
+        <figcaption>
+          <span class="staff__name">Marco Reyes</span>
+          <span class="staff__title">Guest Services</span>
+        </figcaption>
+      </figure>
+      <figure class="card">
+        <img src="images/staff-3.jpg" width="400" height="400" alt="Safety coordinator giving a thumbs up" />
+        <figcaption>
+          <span class="staff__name">Sofia Park</span>
+          <span class="staff__title">Safety Coordinator</span>
+        </figcaption>
+      </figure>
+    </div>
+  </section>
+</main>
+
+  <footer>
+    <p>&copy; 2025 Riverrush Expeditions | Alejandro Vanderhorst</p>
+    <nav class="socialmedia">
+      <a href="#"><img src="images/facebook.png" alt="Facebook" class="icon"></a>
+      <a href="#"><img src="images/twitter.png" alt="Twitter" class="icon"></a>
+      <a href="#"><img src="images/instagram.png" alt="Instagram" class="icon"></a>
+    </nav>
+    <p class="wireframe-link">
+      <a href="https://example.com/contact-wireframe" target="_blank" rel="noopener">Contact Us Wireframe</a>
+    </p>
+  </footer>
+</body>
+</html>

--- a/wwr/images/staff-1.jpg
+++ b/wwr/images/staff-1.jpg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='400' height='400'><rect width='100%' height='100%' fill='#e6f0ff'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='#1a3d6d'>Staff 1</text></svg>

--- a/wwr/images/staff-2.jpg
+++ b/wwr/images/staff-2.jpg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='400' height='400'><rect width='100%' height='100%' fill='#e6ffe6'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='#1a3d6d'>Staff 2</text></svg>

--- a/wwr/images/staff-3.jpg
+++ b/wwr/images/staff-3.jpg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='400' height='400'><rect width='100%' height='100%' fill='#fff0f0'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='#1a3d6d'>Staff 3</text></svg>

--- a/wwr/styles/rafting.css
+++ b/wwr/styles/rafting.css
@@ -168,3 +168,61 @@ h2{
   padding: 0;
   margin: 0;
 }
+/* CONTACT PAGE LAYOUT */
+.contact { 
+  max-width: 1100px; margin-inline: auto; padding: 1rem 1.25rem; 
+}
+.contact h1 { margin-block: 1rem 1.25rem; line-height: 1.2; }
+
+.contact__grid { 
+  display: grid; gap: 1.5rem; 
+  grid-template-columns: 1fr; 
+}
+@media (min-width: 900px) {
+  .contact__grid { grid-template-columns: 1fr 1fr; align-items: start; }
+}
+
+.contact__info address { font-style: normal; line-height: 1.6; }
+.contact__map iframe { width: 100%; height: 280px; border: 0; }
+
+/* FORM */
+.contact__form { 
+  border: 1px solid #ddd; border-radius: .5rem; padding: 1rem; 
+}
+.form__field { margin-block: .75rem; }
+.form__field label { display: block; font-weight: 600; margin-bottom: .35rem; }
+.form__field input[type="text"],
+.form__field input[type="email"],
+.form__field textarea { 
+  width: 100%; padding: .65rem .75rem; border: 1px solid #bbb; border-radius: .375rem; 
+}
+.form__inline { display: flex; align-items: center; gap: .5rem; }
+.form__hint { font-size: .9rem; color: #555; }
+
+.radio-group { display: grid; gap: .5rem; }
+.radio { display: inline-flex; align-items: center; gap: .5rem; }
+
+.btn { 
+  display: inline-block; padding: .7rem 1rem; border-radius: .5rem; border: 1px solid transparent; 
+  cursor: pointer; font-weight: 700; 
+}
+.btn--primary { background: #146ebe; color: #fff; }
+.btn--primary:focus-visible { outline: 3px solid #84c5f4; outline-offset: 2px; }
+
+/* STAFF */
+.staff { margin-block: 2rem; }
+.staff__grid { 
+  display: grid; gap: 1rem; 
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+.card { 
+  border: 1px solid #e3e3e3; border-radius: .75rem; overflow: hidden; background: #fff; 
+}
+.card img { width: 100%; height: auto; display: block; }
+.card figcaption { padding: .75rem; }
+.staff__name { display: block; font-weight: 700; }
+.staff__title { display: block; color: #444; }
+
+/* FOOTER LINK (contact page only) */
+.wireframe-link { text-align: center; margin: 2rem auto 1rem; }
+.wireframe-link a { text-decoration: underline; }


### PR DESCRIPTION
## Summary
- add contact page with company info, map, message form, staff section
- append contact layout and form styles to rafting stylesheet
- include placeholder staff images and wireframe link

## Testing
- `npx -y htmlhint wwr/contact.html` *(fails: 403 Forbidden from npm registry)*


------
https://chatgpt.com/codex/tasks/task_e_689cc69528b88332b33a210ebe1476d2